### PR TITLE
fix auto search when selected text present

### DIFF
--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -43,6 +43,12 @@ const Popup: React.FC = () => {
     loadSelectedText();
   }, []);
 
+  useEffect(() => {
+    if (selectedApp && searchTerm) {
+      performSearch(searchTerm, selectedApp);
+    }
+  }, [selectedApp]);
+
   const loadApps = async () => {
     try {
       const savedApps = await storage.getArrApps();


### PR DESCRIPTION
## Summary
- ensure popup performs search after apps load when initial selected text exists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac508abd1c832dbdce2c6b3567e4ee