### PR TITLE
Refactor Arr APIs into Sonarr and Radarr classes

### DIFF
--- a/src/api/arrApi.ts
+++ b/src/api/arrApi.ts
@@ -1,98 +1,19 @@
-import type { 
-  ArrApp, 
-  SearchResult, 
-  QualityProfile, 
-  RootFolder, 
-  AddSeriesRequest, 
-  AddMovieRequest,
-  SystemStatus 
-} from './types';
+import type { ArrApp } from './types';
+import ArrApiBase from './arrApiBase';
+import { SonarrApi } from './sonarrApi';
+import { RadarrApi } from './radarrApi';
 
-export class ArrApi {
-  private app: ArrApp;
-
-  constructor(app: ArrApp) {
-    this.app = app;
-  }
-
-  private async request(endpoint: string, options: RequestInit = {}) {
-    const url = `${this.app.url}/api/v3${endpoint}`;
-    
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        'X-Api-Key': this.app.apiKey,
-        'Content-Type': 'application/json',
-        ...options.headers,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
-    }
-
-    return response.json();
-  }
-
-  async testConnection(): Promise<SystemStatus> {
-    return this.request('/system/status');
-  }
-
-  async searchSeries(term: string): Promise<SearchResult[]> {
-    if (this.app.type !== 'sonarr') {
-      throw new Error('This method is only available for Sonarr');
-    }
-    return this.request(`/series/lookup?term=${encodeURIComponent(term)}`);
-  }
-
-  async searchMovies(term: string): Promise<SearchResult[]> {
-    if (this.app.type !== 'radarr') {
-      throw new Error('This method is only available for Radarr');
-    }
-    return this.request(`/movie/lookup?term=${encodeURIComponent(term)}`);
-  }
-
-  async getAllSeries(): Promise<SearchResult[]> {
-    if (this.app.type !== 'sonarr') {
-      throw new Error('This method is only available for Sonarr');
-    }
-    return this.request('/series');
-  }
-
-  async getAllMovies(): Promise<SearchResult[]> {
-    if (this.app.type !== 'radarr') {
-      throw new Error('This method is only available for Radarr');
-    }
-    return this.request('/movie');
-  }
-
-  async getQualityProfiles(): Promise<QualityProfile[]> {
-    return this.request('/qualityProfile');
-  }
-
-  async getRootFolders(): Promise<RootFolder[]> {
-    return this.request('/rootfolder');
-  }
-
-  async addSeries(request: AddSeriesRequest): Promise<SearchResult> {
-    if (this.app.type !== 'sonarr') {
-      throw new Error('This method is only available for Sonarr');
-    }
-    return this.request('/series', {
-      method: 'POST',
-      body: JSON.stringify(request),
-    });
-  }
-
-  async addMovie(request: AddMovieRequest): Promise<SearchResult> {
-    if (this.app.type !== 'radarr') {
-      throw new Error('This method is only available for Radarr');
-    }
-    return this.request('/movie', {
-      method: 'POST',
-      body: JSON.stringify(request),
-    });
+export function createArrApi(app: ArrApp & { type: 'sonarr' }): SonarrApi;
+export function createArrApi(app: ArrApp & { type: 'radarr' }): RadarrApi;
+export function createArrApi(app: ArrApp): ArrApiBase {
+  switch (app.type) {
+    case 'sonarr':
+      return new SonarrApi(app);
+    case 'radarr':
+      return new RadarrApi(app);
+    default:
+      throw new Error(`Unsupported app type: ${app.type}`);
   }
 }
 
-export const createArrApi = (app: ArrApp) => new ArrApi(app); 
+export type { ArrApiBase, SonarrApi, RadarrApi };

--- a/src/api/arrApiBase.ts
+++ b/src/api/arrApiBase.ts
@@ -1,0 +1,42 @@
+import type { ArrApp, QualityProfile, RootFolder, SystemStatus } from './types';
+
+export abstract class ArrApiBase {
+  protected app: ArrApp;
+
+  constructor(app: ArrApp) {
+    this.app = app;
+  }
+
+  protected async request(endpoint: string, options: RequestInit = {}) {
+    const url = `${this.app.url}/api/v3${endpoint}`;
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        'X-Api-Key': this.app.apiKey,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async testConnection(): Promise<SystemStatus> {
+    return this.request('/system/status');
+  }
+
+  async getQualityProfiles(): Promise<QualityProfile[]> {
+    return this.request('/qualityProfile');
+  }
+
+  async getRootFolders(): Promise<RootFolder[]> {
+    return this.request('/rootfolder');
+  }
+}
+
+export default ArrApiBase;

--- a/src/api/radarrApi.ts
+++ b/src/api/radarrApi.ts
@@ -1,0 +1,25 @@
+import type { ArrApp, SearchResult, AddMovieRequest } from './types';
+import ArrApiBase from './arrApiBase';
+
+export class RadarrApi extends ArrApiBase {
+  constructor(app: ArrApp) {
+    super(app);
+  }
+
+  async searchMovies(term: string): Promise<SearchResult[]> {
+    return this.request(`/movie/lookup?term=${encodeURIComponent(term)}`);
+  }
+
+  async getAllMovies(): Promise<SearchResult[]> {
+    return this.request('/movie');
+  }
+
+  async addMovie(request: AddMovieRequest): Promise<SearchResult> {
+    return this.request('/movie', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+}
+
+export default RadarrApi;

--- a/src/api/sonarrApi.ts
+++ b/src/api/sonarrApi.ts
@@ -1,0 +1,25 @@
+import type { ArrApp, SearchResult, AddSeriesRequest } from './types';
+import ArrApiBase from './arrApiBase';
+
+export class SonarrApi extends ArrApiBase {
+  constructor(app: ArrApp) {
+    super(app);
+  }
+
+  async searchSeries(term: string): Promise<SearchResult[]> {
+    return this.request(`/series/lookup?term=${encodeURIComponent(term)}`);
+  }
+
+  async getAllSeries(): Promise<SearchResult[]> {
+    return this.request('/series');
+  }
+
+  async addSeries(request: AddSeriesRequest): Promise<SearchResult> {
+    return this.request('/series', {
+      method: 'POST',
+      body: JSON.stringify(request),
+    });
+  }
+}
+
+export default SonarrApi;

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -113,13 +113,12 @@ const AddItemForm: React.FC<AddItemFormProps> = ({ app, result, onSuccess, onCan
     setError(null);
 
     try {
-      const api = createArrApi(app);
-      
       if (app.type === 'sonarr') {
+        const api = createArrApi(app);
         if (!result.tvdbId) {
           throw new Error('Missing TVDB ID for series');
         }
-        
+
         await api.addSeries({
           title: result.title,
           qualityProfileId: selectedQualityProfile,
@@ -133,10 +132,11 @@ const AddItemForm: React.FC<AddItemFormProps> = ({ app, result, onSuccess, onCan
           searchForCutoffUnmetEpisodes: searchForCutoff
         });
       } else if (app.type === 'radarr') {
+        const api = createArrApi(app);
         if (!result.tmdbId) {
           throw new Error('Missing TMDB ID for movie');
         }
-        
+
         await api.addMovie({
           title: result.title,
           qualityProfileId: selectedQualityProfile,
@@ -147,10 +147,10 @@ const AddItemForm: React.FC<AddItemFormProps> = ({ app, result, onSuccess, onCan
           searchForMovie: searchForMissing
         });
       }
-      
+
       // Save options on successful submission
       await saveCurrentOptions();
-      
+
       onSuccess(result);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add item');

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -71,14 +71,15 @@ const Popup: React.FC = () => {
     }
   };
 
-  const loadExistingItems = async (app: ArrApp) => {
+    const loadExistingItems = async (app: ArrApp) => {
     try {
-      const api = createArrApi(app);
       let existingItems: SearchResult[] = [];
-      
+
       if (app.type === 'sonarr') {
+        const api = createArrApi(app);
         existingItems = await api.getAllSeries();
       } else if (app.type === 'radarr') {
+        const api = createArrApi(app);
         existingItems = await api.getAllMovies();
       }
       
@@ -97,22 +98,23 @@ const Popup: React.FC = () => {
     }
   };
 
-  const performSearch = async (term: string, app: ArrApp) => {
+    const performSearch = async (term: string, app: ArrApp) => {
     if (!term.trim()) return;
-    
+
     setLoading(true);
     setError(null);
-    
+
     try {
-      const api = createArrApi(app);
       let results: SearchResult[] = [];
-      
+
       if (app.type === 'sonarr') {
+        const api = createArrApi(app);
         results = await api.searchSeries(term);
       } else if (app.type === 'radarr') {
+        const api = createArrApi(app);
         results = await api.searchMovies(term);
       }
-      
+
       setSearchResults(results);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Search failed');


### PR DESCRIPTION
## Summary
- add `ArrApiBase` abstract class for shared requests
- implement `SonarrApi` and `RadarrApi` classes
- use factory to create correct API and update components accordingly

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac526719d8832d9d139db740e5a20a