### PR TITLE
feat: add API key visibility toggle

### DIFF
--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -706,6 +706,27 @@ body::-webkit-scrollbar-thumb {
   font-size: 14px;
 }
 
+.form-group .input-with-toggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.form-group .input-with-toggle input {
+  width: 100%;
+  padding-right: 50px;
+}
+
+.form-group .input-with-toggle .toggle-password {
+  position: absolute;
+  right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
 .form-group input:focus,
 .form-group select:focus {
   outline: 2px solid var(--ring);

--- a/src/components/AppForm.tsx
+++ b/src/components/AppForm.tsx
@@ -13,6 +13,7 @@ const AppForm: React.FC<AppFormProps> = ({ app, onSubmit, onCancel }) => {
   const [type, setType] = useState<ArrApp['type']>('sonarr');
   const [url, setUrl] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
 
@@ -132,14 +133,23 @@ const AppForm: React.FC<AppFormProps> = ({ app, onSubmit, onCancel }) => {
 
         <div className="form-group">
           <label htmlFor="apiKey">API Key</label>
-          <input
-            type="password"
-            id="apiKey"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="Your API key"
-            required
-          />
+          <div className="input-with-toggle">
+            <input
+              type={showApiKey ? 'text' : 'password'}
+              id="apiKey"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="Your API key"
+              required
+            />
+            <button
+              type="button"
+              className="toggle-password"
+              onClick={() => setShowApiKey((prev) => !prev)}
+            >
+              {showApiKey ? 'Hide' : 'Show'}
+            </button>
+          </div>
           <small className="form-group-description">
             Found in Settings → General → Security in your *arr app
           </small>


### PR DESCRIPTION
## Summary
- add toggle to show or hide the API key in the app form
- style the API key input to accommodate the visibility toggle button
